### PR TITLE
add cache no método SQSTask.apply e os testes

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,27 @@ dead_task.run()
 Verificação de e-mail:
 
 - [EmailListVerifyOne](/docs/tools/email_verify.md)
+
+## Gestão de Cache em processamento de Task com SQSTask
+
+Objetivo do cache na classe `SQSTask` é evitar duplicidade de processamento de tasks, através de uma verificação de `cache` a classe consegue identificar se determinada task foi ou não processada. Abaixo um exemplo de aplicação:
+
+> Exemplo de como fazer o uso do cache
+
+```python
+@SQSTask(once_time=60*60)
+def foo(param_a, param_b):
+    return "bar"
+```
+
+O parâmetro `once_time` é a definição do tempo de cache de uma determinada task.
+
+> Exemplo de como `não` fazer o uso do cache
+
+```python
+@SQSTask()
+def foo(param_a, param_b):
+    return "bar"
+```
+
+Caso o parâmetro `once_time` não seja informado, quando chamar a task por `default` o valor será `None`. Dessa forma, não utilizando o `cache` da classe SQSTask.

--- a/alfred/sqs/sqs.py
+++ b/alfred/sqs/sqs.py
@@ -27,7 +27,7 @@ class SQSTask:
     default_retry_delay = DEFAULT_RETRY_DELAY
 
     def __init__(
-        self, bind=False, retries=0, queue_url=None, dead_retry=False, once_time=60
+        self, bind=False, retries=0, queue_url=None, dead_retry=False, once_time=None
     ):
         self.dead_retry = dead_retry
         self.retries = retries

--- a/tests/sqs/test_sqs.py
+++ b/tests/sqs/test_sqs.py
@@ -41,13 +41,18 @@ def foo(param_a, param_b):
     return "bar"
 
 
+@SQSTask()
+def foobar(param_a, param_b):
+    return "bar"
+
+
 def test_sqs_task_init():
     assert foo.bind is False
     assert foo.retries == 0
 
 
 def test_sqs_task_apply():
-    response = foo.apply(args=["fubar"], kwargs={"param_b": 10})
+    response = foobar.apply(args=["fubar"], kwargs={"param_b": 10})
     assert response == "bar"
 
 
@@ -83,7 +88,11 @@ def test_apply_async(mock_sqs_client):
 
 @patch("alfred.sqs.sqs.sqs_client")
 def test_apply_async_with_countdown(mock_sqs_client):
-    response = foo.apply_async(args=["fubar"], kwargs={"param_b": 10}, countdown=30,)
+    response = foo.apply_async(
+        args=["fubar"],
+        kwargs={"param_b": 10},
+        countdown=30,
+    )
 
     mock_sqs_client.send_message.assert_called_once_with(
         QueueUrl=foo.queue_url,
@@ -104,7 +113,9 @@ def test_apply_async_with_countdown(mock_sqs_client):
 @patch("alfred.sqs.sqs.sqs_client")
 def test_apply_async_with_queue_url(mock_sqs_client):
     response = foo.apply_async(
-        args=["fubar"], kwargs={"param_b": 10}, queue_url="fake-queue",
+        args=["fubar"],
+        kwargs={"param_b": 10},
+        queue_url="fake-queue",
     )
 
     mock_sqs_client.send_message.assert_called_once_with(
@@ -279,3 +290,18 @@ def test_sqs_send_dead_task(dynamo_setup):
     dead_task = DeadTask.scan().__next__()
 
     dead_task.run()
+
+
+@SQSTask(bind=True)
+def foo_return_bar(self, args, kwargs):
+    return "bar"
+
+
+@patch("alfred.cache.walrus_cache.Cache.get")
+@patch("alfred.cache.walrus_cache.Cache.set")
+def test_check_cache_already_existed(mock_cache_set, mock_cache_get):
+    mock_cache_get.return_value = True
+
+    foo_return_bar.apply(args=["foobar"], kwargs={"param_b": 10})
+
+    mock_cache_set.assert_not_called()

--- a/tests/sqs/test_sqs.py
+++ b/tests/sqs/test_sqs.py
@@ -293,15 +293,25 @@ def test_sqs_send_dead_task(dynamo_setup):
 
 
 @SQSTask(bind=True)
-def foo_return_bar(self, args, kwargs):
+def foo_return_bar(self, *args, **kwargs):
     return "bar"
 
 
 @patch("alfred.cache.walrus_cache.Cache.get")
 @patch("alfred.cache.walrus_cache.Cache.set")
-def test_check_cache_already_existed(mock_cache_set, mock_cache_get):
+def test_check_sqs_with_cache(mock_cache_set, mock_cache_get):
     mock_cache_get.return_value = True
 
     foo_return_bar.apply(args=["foobar"], kwargs={"param_b": 10})
 
     mock_cache_set.assert_not_called()
+
+
+@patch("alfred.cache.walrus_cache.Cache.get")
+@patch("alfred.cache.walrus_cache.Cache.set")
+def test_check_sqs_without_cache(mock_cache_set, mock_cache_get):
+    mock_cache_get.return_value = False
+
+    foo_return_bar.apply(args=["foobar"], kwargs={"param_b": 10})
+
+    mock_cache_set.assert_called_once()

--- a/tests/sqs/test_sqs.py
+++ b/tests/sqs/test_sqs.py
@@ -292,7 +292,7 @@ def test_sqs_send_dead_task(dynamo_setup):
     dead_task.run()
 
 
-@SQSTask(bind=True)
+@SQSTask(bind=True, once_time=60)
 def foo_return_bar(self, *args, **kwargs):
     return "bar"
 


### PR DESCRIPTION
- Faz o setup do cache no método `SQSTask.apply`
- Adiciona os testes de `test_check_cache_already_existed`
- Adiciona task `foo_return_bar` e `foobar` para realizar os testes. 