### PR TITLE
68 adicionar message id no sqs handler

### DIFF
--- a/alfred/sqs/handlers.py
+++ b/alfred/sqs/handlers.py
@@ -8,16 +8,32 @@ class BaseHandler:
     def __init__(self, body):
         self.body = json.loads(body)
 
-    def apply(self):
+    def get_sqs_task(self):
         module = importlib.import_module(self.body["_func_module"])
-        sqs_task = getattr(module, self.body["_func_name"])
+        self.sqs_task = getattr(module, self.body["_func_name"])
+        self.config_sqs_task()
+        
+    def config_sqs_task(self):
+        pass  # pragma: no cover
 
-        return sqs_task._run(
+    def apply(self):
+        self.get_sqs_task()
+
+        return self.sqs_task._run(
             self.body["retries"], *self.body["args"], **self.body["kwargs"]
         )
 
 
 class SQSHandler(BaseHandler):
+    def __init__(self, body, aws_request_id=None, message_id=None):
+        super().__init__(body)
+        self.aws_request_id = aws_request_id
+        self.message_id = message_id
+    
+    def config_sqs_task(self):
+        self.sqs_task.message_id = self.message_id
+        self.sqs_task.aws_request_id = self.aws_request_id
+
     def sqs_delete_message(self, queue_url, receipt_handle):
         sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
 

--- a/alfred/sqs/setup.py
+++ b/alfred/sqs/setup.py
@@ -9,12 +9,21 @@ logger = logging.getLogger("base")
 def handle_sqs_message(event, queue_url=None):
     queue_url = queue_url or SQS_QUEUE_URL
     for record in event:
-        handler = SQSHandler(body=record.body)
+        record_dict = record.to_dict()
+
+        aws_request_id = record.context.aws_request_id
+        body = record_dict["body"]
+        message_id = record_dict["messageId"]
+
+        handler = SQSHandler(body, aws_request_id, message_id)
+        
         try:
             response = handler.apply()
         except Exception as err:
             logger.debug(
                 {
+                    "sqs_message_id": message_id,
+                    "aws_request_id": aws_request_id,
                     "task_has_succeeded": False,
                     "task_error_message": str(err),
                     "task_function_module": handler.body["_func_module"],
@@ -29,6 +38,8 @@ def handle_sqs_message(event, queue_url=None):
         else:
             logger.debug(
                 {
+                    "sqs_message_id": message_id,
+                    "aws_request_id": aws_request_id,
                     "task_has_succeeded": True,
                     "task_error_message": None,
                     "task_function_module": handler.body["_func_module"],


### PR DESCRIPTION
Exemplo de Record que podemos receber na execução do SQS:

```
{
  'Records': [
    {
      'messageId': '205f8d72-6cb3-4863-b101-652468fcdbbd',
      'receiptHandle': 'AQEBRrukad12N7TIpKthf1ACdbybUHrGIrL/c8PbrYeDgw4kWnHNCmQ1FoFYcrTu+xtG1bUENLtyh++VBn+Gcf3Kmpv4j8pxaNeX11TMGQJV4SvEhMR06UM1iNzciyZYdYQ2WKM3bd6uWGRPH4bwNZeUBCrxnNWuk29vY+2RHce0PVuIkaeu//ZZ5w3QbE64w7DruJUkt6tx7QNjdmPnMs6ISg0J975oyRKOEXa97En3g7MA8SCJkNHuJV6W5zeBzzSNouYupgBasTJQFTVGUlZHvMzJLhhHAV1fG5wzVMRtBTFtQLj/gp0gXzr5HO2RqQE93Ye+CRxkp01bhlT0uLSRxwhUDk2T3iHDWLSG4eOSc/wpHL+mKs6z4mj6YNeJ1h1dyEsniElEqBwqAGkQ7b3O5Q==',
      'body': 'trocar esse body!',
      'attributes': {
        'ApproximateReceiveCount': '1',
        'SentTimestamp': '1656595860604',
        'SenderId': '413370623743',
        'ApproximateFirstReceiveTimestamp': '1656595860612'
      },
      'messageAttributes': {
        
      },
      'md5OfBody': 'a3625d30d7be4c4f00ad3116a3339c87',
      'eventSource': 'aws:sqs',
      'eventSourceARN': 'arn:aws:sqs:us-east-1:413370623743:codechallenge',
      'awsRegion': 'us-east-1'
    }
  ]
}
```